### PR TITLE
Added routing to Formatter input

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,7 @@ subprojects {
 
     group = "com.aerospike"
 
-    project.extra["jacksonVersion"] = "2.15.0"
+    project.extra["jacksonVersion"] = "2.15.1"
 
     setupJavaBuild()
     setupReleaseTasks()

--- a/buildSrc/src/main/kotlin/com/aerospike/connect/JavaExtensions.kt
+++ b/buildSrc/src/main/kotlin/com/aerospike/connect/JavaExtensions.kt
@@ -33,8 +33,8 @@ import org.gradle.kotlin.dsl.provideDelegate
  */
 fun Project.setupJavaBuild() {
     val compileJava: JavaCompile by tasks
-    compileJava.sourceCompatibility = "1.8"
-    compileJava.targetCompatibility = "1.8"
+    compileJava.sourceCompatibility = "11"
+    compileJava.targetCompatibility = "11"
     compileJava.options.apply {
         compilerArgs.add("-Xlint:all")
         compilerArgs.add("-Werror")

--- a/buildSrc/src/main/kotlin/com/aerospike/connect/JavaExtensions.kt
+++ b/buildSrc/src/main/kotlin/com/aerospike/connect/JavaExtensions.kt
@@ -33,8 +33,8 @@ import org.gradle.kotlin.dsl.provideDelegate
  */
 fun Project.setupJavaBuild() {
     val compileJava: JavaCompile by tasks
-    compileJava.sourceCompatibility = "11"
-    compileJava.targetCompatibility = "11"
+    compileJava.sourceCompatibility = "1.8"
+    compileJava.targetCompatibility = "1.8"
     compileJava.options.apply {
         compilerArgs.add("-Xlint:all")
         compilerArgs.add("-Werror")

--- a/elasticsearch-outbound-sdk/build.gradle.kts
+++ b/elasticsearch-outbound-sdk/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     api(project(":aerospike-connect-outbound-sdk"))
 
     // Elasticsearch client
-    api("co.elastic.clients:elasticsearch-java:8.5.0")
+    api("co.elastic.clients:elasticsearch-java:8.7.1")
 
     // Jackson annotations
     compileOnly(

--- a/elasticsearch-outbound-sdk/gradle.properties
+++ b/elasticsearch-outbound-sdk/gradle.properties
@@ -15,4 +15,4 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 #
-version=2.0.0
+version=2.0.0-SNAPSHOT

--- a/elasticsearch-outbound-sdk/gradle.properties
+++ b/elasticsearch-outbound-sdk/gradle.properties
@@ -15,4 +15,4 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 #
-version=1.0.1
+version=2.0.0

--- a/elasticsearch-outbound-sdk/src/main/java/com/aerospike/connect/outbound/elasticsearch/config/BulkRequestConfig.java
+++ b/elasticsearch-outbound-sdk/src/main/java/com/aerospike/connect/outbound/elasticsearch/config/BulkRequestConfig.java
@@ -88,11 +88,12 @@ public class BulkRequestConfig {
     DynamicFieldSource routing;
 
     /**
-     * Explicit operation timeout. Supported timeout units are:
+     * Explicit operation timeout.
      * <table>
+     *   <caption>Supported timeout units</caption>
      *   <tr>
-     *      <td>Unit</td>
-     *      <td>Example</td>
+     *      <th>Unit</th>
+     *      <th>Example</th>
      *   </tr>
      *   <tr>
      *       <td>m - Minutes</td>

--- a/elasticsearch-outbound-sdk/src/main/java/com/aerospike/connect/outbound/elasticsearch/config/BulkRequestConfig.java
+++ b/elasticsearch-outbound-sdk/src/main/java/com/aerospike/connect/outbound/elasticsearch/config/BulkRequestConfig.java
@@ -25,6 +25,7 @@ import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.util.TaggedUnion;
 import com.aerospike.connect.outbound.config.DynamicFieldSource;
 import com.aerospike.connect.outbound.format.BatchFormatter;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.NonNull;
@@ -85,6 +86,7 @@ public class BulkRequestConfig {
      * @return specific shard routing value.
      */
     @Nullable
+    @JsonAlias("shard-routing")
     DynamicFieldSource routing;
 
     /**

--- a/elasticsearch-outbound-sdk/src/main/java/com/aerospike/connect/outbound/elasticsearch/config/BulkRequestConfig.java
+++ b/elasticsearch-outbound-sdk/src/main/java/com/aerospike/connect/outbound/elasticsearch/config/BulkRequestConfig.java
@@ -19,7 +19,6 @@
 package com.aerospike.connect.outbound.elasticsearch.config;
 
 import co.elastic.clients.elasticsearch._types.Refresh;
-import co.elastic.clients.elasticsearch._types.Time;
 import co.elastic.clients.elasticsearch._types.VersionType;
 import co.elastic.clients.elasticsearch._types.WaitForActiveShards;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
@@ -89,13 +88,39 @@ public class BulkRequestConfig {
     DynamicFieldSource routing;
 
     /**
-     * See {@link BulkRequest#timeout()}.
+     * Explicit operation timeout. Supported timeout units are:
+     * <table>
+     *   <tr>
+     *      <td>Unit</td>
+     *      <td>Example</td>
+     *   </tr>
+     *   <tr>
+     *       <td>m - Minutes</td>
+     *       <td>1m</td>
+     *   </tr>
+     *   <tr>
+     *       <td>s - Seconds</td>
+     *       <td>10s</td>
+     *   </tr>
+     *   <tr>
+     *       <td>ms - Milliseconds</td>
+     *       <td>200ms</td>
+     *   </tr>
+     *   <tr>
+     *       <td>micros - Microseconds</td>
+     *       <td>10000micros</td>
+     *   </tr>
+     *   <tr>
+     *       <td>nanos - Nanoseconds</td>
+     *       <td>100000nanos</td>
+     *   </tr>
+     * </table>
      *
      * @param timeout Explicit operation timeout.
      * @return explicit operation timeout.
      */
     @Nullable
-    Time timeout;
+    String timeout;
 
     /**
      * See {@link BulkRequest#waitForActiveShards()}.
@@ -195,7 +220,7 @@ public class BulkRequestConfig {
                 refresh == that.refresh &&
                 Objects.equals(requireAlias, that.requireAlias) &&
                 Objects.equals(routing, that.routing) &&
-                taggedUnionEquals(timeout, that.timeout) &&
+                Objects.equals(timeout, that.timeout) &&
                 taggedUnionEquals(waitForActiveShards,
                         that.waitForActiveShards) &&
                 aerospikeWriteOperationMapping.equals(

--- a/elasticsearch-outbound-sdk/src/main/java/com/aerospike/connect/outbound/elasticsearch/config/BulkRequestConfig.java
+++ b/elasticsearch-outbound-sdk/src/main/java/com/aerospike/connect/outbound/elasticsearch/config/BulkRequestConfig.java
@@ -43,15 +43,6 @@ import java.util.Objects;
 @Value
 public class BulkRequestConfig {
     /**
-     * See {@link BulkRequest#index()}.
-     *
-     * @param index Index for each individual operation.
-     * @return index for each individual operation.
-     */
-    @NonNull
-    DynamicFieldSource index;
-
-    /**
      * See {@link BulkRequest#pipeline()}.
      *
      * @param pipeline The pipeline id to preprocess incoming documents with.
@@ -193,8 +184,7 @@ public class BulkRequestConfig {
             return false;
         }
         BulkRequestConfig that = (BulkRequestConfig) o;
-        return index.equals(that.index) &&
-                Objects.equals(pipeline, that.pipeline) &&
+        return Objects.equals(pipeline, that.pipeline) &&
                 refresh == that.refresh &&
                 Objects.equals(requireAlias, that.requireAlias) &&
                 Objects.equals(routing, that.routing) &&
@@ -212,7 +202,7 @@ public class BulkRequestConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(index, pipeline, refresh, requireAlias, routing,
+        return Objects.hash(pipeline, refresh, requireAlias, routing,
                 timeout, waitForActiveShards, aerospikeWriteOperationMapping,
                 ifPrimaryTerm, ifSeqNo, version, versionType,
                 ignoreAerospikeDelete);

--- a/elasticsearch-outbound-sdk/src/main/java/com/aerospike/connect/outbound/elasticsearch/config/BulkRequestConfig.java
+++ b/elasticsearch-outbound-sdk/src/main/java/com/aerospike/connect/outbound/elasticsearch/config/BulkRequestConfig.java
@@ -25,6 +25,7 @@ import co.elastic.clients.elasticsearch._types.WaitForActiveShards;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.util.TaggedUnion;
 import com.aerospike.connect.outbound.config.DynamicFieldSource;
+import com.aerospike.connect.outbound.format.BatchFormatter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.NonNull;
@@ -42,6 +43,12 @@ import java.util.Objects;
 @Jacksonized
 @Value
 public class BulkRequestConfig {
+    /**
+     * A constant for injecting {@link BulkRequestConfig} into custom
+     * {@link BatchFormatter} implementation.
+     */
+    public static final String BULK_REQUEST_CONFIG_NAME = "bulk-request-config";
+
     /**
      * See {@link BulkRequest#pipeline()}.
      *

--- a/examples/gradle/build.gradle.kts
+++ b/examples/gradle/build.gradle.kts
@@ -67,16 +67,16 @@ dependencies {
 // Plugin should be compiled with the same/compatible Java version running
 // the outbound connector.
 val compileJava: JavaCompile by tasks
-compileJava.sourceCompatibility = "11"
-compileJava.targetCompatibility = "11"
+compileJava.sourceCompatibility = "1.8"
+compileJava.targetCompatibility = "1.8"
 compileJava.options.apply {
     compilerArgs.add("-Xlint:all")
     compilerArgs.add("-Werror")
 }
 
 val compileTestJava: JavaCompile by tasks
-compileTestJava.sourceCompatibility = "11"
-compileTestJava.targetCompatibility = "11"
+compileTestJava.sourceCompatibility = "1.8"
+compileTestJava.targetCompatibility = "1.8"
 compileTestJava.options.apply {
     compilerArgs.add("-Xlint:all")
     compilerArgs.add("-Werror")

--- a/examples/gradle/build.gradle.kts
+++ b/examples/gradle/build.gradle.kts
@@ -43,15 +43,15 @@ configurations.all {
 
 dependencies {
     // Aerospike client.
-    compileOnly("com.aerospike:aerospike-client:6.1.9")
+    compileOnly("com.aerospike:aerospike-client:6.1.10")
 
     // JSON formatting in some examples.
-    api("com.fasterxml.jackson.core:jackson-databind:2.15.0")
+    api("com.fasterxml.jackson.core:jackson-databind:2.15.1")
 
     // Aerospike outbound SDK.
     compileOnly("com.aerospike:aerospike-connect-outbound-sdk:2.0.0-SNAPSHOT")
     compileOnly(
-        "com.aerospike:aerospike-connect-elasticsearch-outbound-sdk:1.0.0"
+        "com.aerospike:aerospike-connect-elasticsearch-outbound-sdk:2.0.0-SNAPSHOT"
     )
 
     // Logging.

--- a/examples/gradle/build.gradle.kts
+++ b/examples/gradle/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     api("com.fasterxml.jackson.core:jackson-databind:2.15.0")
 
     // Aerospike outbound SDK.
-    compileOnly("com.aerospike:aerospike-connect-outbound-sdk:1.2.0")
+    compileOnly("com.aerospike:aerospike-connect-outbound-sdk:2.0.0-SNAPSHOT")
     compileOnly(
         "com.aerospike:aerospike-connect-elasticsearch-outbound-sdk:1.0.0"
     )
@@ -67,16 +67,16 @@ dependencies {
 // Plugin should be compiled with the same/compatible Java version running
 // the outbound connector.
 val compileJava: JavaCompile by tasks
-compileJava.sourceCompatibility = "1.8"
-compileJava.targetCompatibility = "1.8"
+compileJava.sourceCompatibility = "11"
+compileJava.targetCompatibility = "11"
 compileJava.options.apply {
     compilerArgs.add("-Xlint:all")
     compilerArgs.add("-Werror")
 }
 
 val compileTestJava: JavaCompile by tasks
-compileTestJava.sourceCompatibility = "1.8"
-compileTestJava.targetCompatibility = "1.8"
+compileTestJava.sourceCompatibility = "11"
+compileTestJava.targetCompatibility = "11"
 compileTestJava.options.apply {
     compilerArgs.add("-Xlint:all")
     compilerArgs.add("-Werror")

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/elasticsearch/ElasticsearchCustomJsonBatchFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/elasticsearch/ElasticsearchCustomJsonBatchFormatter.java
@@ -21,6 +21,7 @@ package com.aerospike.connect.outbound.transformer.examples.elasticsearch;
 import co.elastic.clients.elasticsearch.core.BulkRequest.Builder;
 import co.elastic.clients.elasticsearch.core.bulk.CreateOperation;
 import com.aerospike.connect.outbound.elasticsearch.ElasticsearchOutboundMetadata;
+import com.aerospike.connect.outbound.elasticsearch.config.BulkRequestConfig;
 import com.aerospike.connect.outbound.elasticsearch.format.ElasticsearchOutboundRecord;
 import com.aerospike.connect.outbound.format.BatchFormatter;
 import com.aerospike.connect.outbound.format.BatchItem;
@@ -30,11 +31,15 @@ import lombok.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static com.aerospike.connect.outbound.elasticsearch.config.BulkRequestConfig.BULK_REQUEST_CONFIG_NAME;
 
 /**
  * ElasticsearchCustomJsonBatchFormatter formats change notification records by
@@ -57,11 +62,18 @@ public class ElasticsearchCustomJsonBatchFormatter
                     ElasticsearchCustomJsonBatchFormatter.class.getName());
 
     private final static ObjectMapper objectMapper = new ObjectMapper();
+    private final BulkRequestConfig bulkRequestConfig;
+
+    @Inject
+    public ElasticsearchCustomJsonBatchFormatter(
+            @Named(BULK_REQUEST_CONFIG_NAME)
+            BulkRequestConfig bulkRequestConfig) {
+        this.bulkRequestConfig = bulkRequestConfig;
+    }
 
     @Override
     public List<OutboundRecord<ElasticsearchOutboundMetadata>> format(
-            @NonNull List<BatchItem<ElasticsearchOutboundMetadata>> batchItems)
-            throws Exception {
+            @NonNull List<BatchItem<ElasticsearchOutboundMetadata>> batchItems) {
         ElasticsearchOutboundRecord elasticsearchOutboundRecord =
                 getElasticsearchOutboundRecord(batchItems);
         List<OutboundRecord<ElasticsearchOutboundMetadata>>
@@ -100,6 +112,8 @@ public class ElasticsearchCustomJsonBatchFormatter
                                                     // operation.
                                                     cob.index((String) esIndex);
                                                 }
+                                                cob.pipeline(
+                                                        bulkRequestConfig.getPipeline());
                                                 return cob;
                                             })
                                     ));

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/elasticsearch/ElasticsearchCustomJsonFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/elasticsearch/ElasticsearchCustomJsonFormatter.java
@@ -57,8 +57,7 @@ public class ElasticsearchCustomJsonFormatter
 
     @Override
     public OutboundRecord<ElasticsearchOutboundMetadata> format(
-            @NonNull FormatterInput<ElasticsearchOutboundMetadata> formatterInput)
-            throws Exception {
+            @NonNull FormatterInput<ElasticsearchOutboundMetadata> formatterInput) {
         logger.debug("Formatting record {}",
                 formatterInput.getRecord().getMetadata().getKey());
         Map<String, Object> bins = formatterInput.getRecord().getBins();

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/elasticsearch/ElasticsearchCustomJsonFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/elasticsearch/ElasticsearchCustomJsonFormatter.java
@@ -20,10 +20,10 @@ package com.aerospike.connect.outbound.transformer.examples.elasticsearch;
 
 import co.elastic.clients.elasticsearch.core.BulkRequest.Builder;
 import co.elastic.clients.elasticsearch.core.bulk.CreateOperation;
-import com.aerospike.connect.outbound.ChangeNotificationRecord;
 import com.aerospike.connect.outbound.elasticsearch.ElasticsearchOutboundMetadata;
 import com.aerospike.connect.outbound.elasticsearch.format.ElasticsearchOutboundRecord;
 import com.aerospike.connect.outbound.format.Formatter;
+import com.aerospike.connect.outbound.format.FormatterInput;
 import com.aerospike.connect.outbound.format.OutboundRecord;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.NonNull;
@@ -35,8 +35,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * ElasticsearchCustomJsonFormatter formats change notification record by
- * adding an extra field named 'created_at' along with the parsed bins.
+ * ElasticsearchCustomJsonFormatter formats change notification record by adding
+ * an extra field named 'created_at' along with the parsed bins.
  *
  * <p>
  * A snippet of a config for this formatter can be
@@ -50,16 +50,18 @@ import java.util.Map;
 public class ElasticsearchCustomJsonFormatter
         implements Formatter<ElasticsearchOutboundMetadata> {
     private final static Logger logger =
-            LoggerFactory.getLogger(ElasticsearchCustomJsonFormatter.class.getName());
+            LoggerFactory.getLogger(
+                    ElasticsearchCustomJsonFormatter.class.getName());
 
     private final static ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public OutboundRecord<ElasticsearchOutboundMetadata> format(
-            @NonNull ChangeNotificationRecord record,
-            @NonNull OutboundRecord<ElasticsearchOutboundMetadata> formattedRecord) {
-        logger.debug("Formatting record {}", record.getMetadata().getKey());
-        Map<String, Object> bins = record.getBins();
+            @NonNull FormatterInput<ElasticsearchOutboundMetadata> formatterInput)
+            throws Exception {
+        logger.debug("Formatting record {}",
+                formatterInput.getRecord().getMetadata().getKey());
+        Map<String, Object> bins = formatterInput.getRecord().getBins();
         Map<String, Object> resultMap = new HashMap<>(bins.size() + 1);
         resultMap.putAll(bins);
         resultMap.put("created_at", System.currentTimeMillis());

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/elasticsearch/ElasticsearchSkipFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/elasticsearch/ElasticsearchSkipFormatter.java
@@ -20,12 +20,12 @@ package com.aerospike.connect.outbound.transformer.examples.elasticsearch;
 
 import co.elastic.clients.elasticsearch.core.BulkRequest.Builder;
 import co.elastic.clients.elasticsearch.core.bulk.IndexOperation;
-import com.aerospike.connect.outbound.ChangeNotificationRecord;
 import com.aerospike.connect.outbound.elasticsearch.ElasticsearchOutboundMetadata;
 import com.aerospike.connect.outbound.elasticsearch.format.ElasticsearchOutboundRecord;
 import com.aerospike.connect.outbound.format.BytesOutboundRecord;
 import com.aerospike.connect.outbound.format.Formatter;
 import com.aerospike.connect.outbound.format.FormatterConfig;
+import com.aerospike.connect.outbound.format.FormatterInput;
 import com.aerospike.connect.outbound.format.MediaType;
 import com.aerospike.connect.outbound.format.OutboundRecord;
 import com.aerospike.connect.outbound.format.SkipOutboundRecord;
@@ -72,21 +72,24 @@ public class ElasticsearchSkipFormatter
 
     @Override
     public OutboundRecord<ElasticsearchOutboundMetadata> format(
-            @NonNull ChangeNotificationRecord record,
-            @NonNull OutboundRecord<ElasticsearchOutboundMetadata> formattedRecord) {
-        logger.debug("Formatting record {}", record.getMetadata().getKey());
+            @NonNull FormatterInput<ElasticsearchOutboundMetadata> formatterInput)
+            throws Exception {
+        logger.debug("Formatting record {}",
+                formatterInput.getRecord().getMetadata().getKey());
 
         // Record generation is not shipped by Aerospike XDR versions before
         // v5.0.0.
-        Optional<Integer> generation = record.getMetadata().getGeneration();
+        Optional<Integer> generation =
+                formatterInput.getRecord().getMetadata().getGeneration();
 
         // "genNumber" is to be set in params option of the Elasticsearch
         // formatter config.
         if (generation.isPresent() &&
                 generation.get() > (int) configParams.get("genNumber")) {
-            logger.debug("Skipping record {}", record.getMetadata().getKey());
+            logger.debug("Skipping record {}",
+                    formatterInput.getRecord().getMetadata().getKey());
             return new SkipOutboundRecord<>(MediaType.OCTET_STREAM,
-                    formattedRecord.getMetadata());
+                    formatterInput.getFormattedRecord().getMetadata());
         }
 
         // Return built-in JSON formatted record.
@@ -95,9 +98,8 @@ public class ElasticsearchSkipFormatter
                 Builder builder = new Builder();
                 builder.index("my_test_index");
                 @SuppressWarnings({"rawtypes", "OptionalGetWithoutIsPresent"})
-                byte[] value =
-                        (byte[]) ((BytesOutboundRecord) formattedRecord).getPayload()
-                                .get();
+                byte[] value = (byte[]) ((BytesOutboundRecord)
+                        formatterInput.getFormattedRecord()).getPayload().get();
                 builder.operations(op -> op.index(IndexOperation.of(iob -> {
                             iob.document(new PreSerializedJson(value));
                             iob.id("3642380");

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/elasticsearch/ElasticsearchSkipFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/elasticsearch/ElasticsearchSkipFormatter.java
@@ -72,8 +72,7 @@ public class ElasticsearchSkipFormatter
 
     @Override
     public OutboundRecord<ElasticsearchOutboundMetadata> format(
-            @NonNull FormatterInput<ElasticsearchOutboundMetadata> formatterInput)
-            throws Exception {
+            @NonNull FormatterInput<ElasticsearchOutboundMetadata> formatterInput) {
         logger.debug("Formatting record {}",
                 formatterInput.getRecord().getMetadata().getKey());
 

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/elasticsearch/ElasticsearchSkipTransformer.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/elasticsearch/ElasticsearchSkipTransformer.java
@@ -60,7 +60,7 @@ public class ElasticsearchSkipTransformer implements Transformer {
 
     @Override
     public ChangeNotificationRecord transform(
-            @NonNull ChangeNotificationRecord record) throws Exception {
+            @NonNull ChangeNotificationRecord record) {
         // Record generation is not shipped by Aerospike XDR versions before
         // v5.0.0.
         Optional<Integer> generation = record.getMetadata().getGeneration();

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/esp/EspKeyValueFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/esp/EspKeyValueFormatter.java
@@ -18,11 +18,11 @@
 
 package com.aerospike.connect.outbound.transformer.examples.esp;
 
-import com.aerospike.connect.outbound.ChangeNotificationRecord;
 import com.aerospike.connect.outbound.esp.EspOutboundMetadata;
 import com.aerospike.connect.outbound.format.DefaultTextOutboundRecord;
 import com.aerospike.connect.outbound.format.Formatter;
 import com.aerospike.connect.outbound.format.FormatterConfig;
+import com.aerospike.connect.outbound.format.FormatterInput;
 import com.aerospike.connect.outbound.format.MediaType;
 import com.aerospike.connect.outbound.format.OutboundRecord;
 import lombok.NonNull;
@@ -64,15 +64,17 @@ public class EspKeyValueFormatter implements Formatter<EspOutboundMetadata> {
 
     @Override
     public OutboundRecord<EspOutboundMetadata> format(
-            @NonNull ChangeNotificationRecord record,
-            @NonNull OutboundRecord<EspOutboundMetadata> formattedRecord) {
-        logger.debug("Formatting record {}", record.getMetadata().getKey());
+            @NonNull FormatterInput<EspOutboundMetadata> formatterInput)
+            throws Exception {
+        logger.debug("Formatting record {}",
+                formatterInput.getRecord().getMetadata().getKey());
 
         // Only write string bins.
         StringBuilder payloadBuilder = new StringBuilder();
         String separator =
                 (String) configParams.getOrDefault("separator", ":");
-        for (Map.Entry<String, Object> bin : record.getBins().entrySet()) {
+        for (Map.Entry<String, Object> bin : formatterInput.getRecord()
+                .getBins().entrySet()) {
             if (bin.getValue() instanceof String) {
                 payloadBuilder.append(bin.getKey());
                 payloadBuilder.append(separator);
@@ -83,6 +85,7 @@ public class EspKeyValueFormatter implements Formatter<EspOutboundMetadata> {
 
         return new DefaultTextOutboundRecord<>(
                 payloadBuilder.toString().getBytes(), MediaType.OCTET_STREAM,
-                formattedRecord.getMetadata(), Collections.emptySet());
+                formatterInput.getFormattedRecord().getMetadata(),
+                Collections.emptySet());
     }
 }

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/esp/EspKeyValueFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/esp/EspKeyValueFormatter.java
@@ -64,8 +64,7 @@ public class EspKeyValueFormatter implements Formatter<EspOutboundMetadata> {
 
     @Override
     public OutboundRecord<EspOutboundMetadata> format(
-            @NonNull FormatterInput<EspOutboundMetadata> formatterInput)
-            throws Exception {
+            @NonNull FormatterInput<EspOutboundMetadata> formatterInput) {
         logger.debug("Formatting record {}",
                 formatterInput.getRecord().getMetadata().getKey());
 

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/esp/EspSkipFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/esp/EspSkipFormatter.java
@@ -66,8 +66,7 @@ public class EspSkipFormatter implements Formatter<EspOutboundMetadata> {
 
     @Override
     public OutboundRecord<EspOutboundMetadata> format(
-            @NonNull FormatterInput<EspOutboundMetadata> formatterInput)
-            throws Exception {
+            @NonNull FormatterInput<EspOutboundMetadata> formatterInput) {
         logger.debug("Formatting record {}",
                 formatterInput.getRecord().getMetadata().getKey());
 

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/esp/EspSkipFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/esp/EspSkipFormatter.java
@@ -18,10 +18,10 @@
 
 package com.aerospike.connect.outbound.transformer.examples.esp;
 
-import com.aerospike.connect.outbound.ChangeNotificationRecord;
 import com.aerospike.connect.outbound.esp.EspOutboundMetadata;
 import com.aerospike.connect.outbound.format.Formatter;
 import com.aerospike.connect.outbound.format.FormatterConfig;
+import com.aerospike.connect.outbound.format.FormatterInput;
 import com.aerospike.connect.outbound.format.MediaType;
 import com.aerospike.connect.outbound.format.OutboundRecord;
 import com.aerospike.connect.outbound.format.SkipOutboundRecord;
@@ -66,24 +66,27 @@ public class EspSkipFormatter implements Formatter<EspOutboundMetadata> {
 
     @Override
     public OutboundRecord<EspOutboundMetadata> format(
-            @NonNull ChangeNotificationRecord record,
-            @NonNull OutboundRecord<EspOutboundMetadata> formattedRecord) {
-        logger.debug("Formatting record {}", record.getMetadata().getKey());
+            @NonNull FormatterInput<EspOutboundMetadata> formatterInput)
+            throws Exception {
+        logger.debug("Formatting record {}",
+                formatterInput.getRecord().getMetadata().getKey());
 
         // Record generation is not shipped by Aerospike XDR versions before
         // v5.0.0.
-        Optional<Integer> generation = record.getMetadata().getGeneration();
+        Optional<Integer> generation =
+                formatterInput.getRecord().getMetadata().getGeneration();
 
         // "genNumber" is to be set in params option of the ESP formatter
         // config.
         if (generation.isPresent() &&
                 generation.get() > (int) configParams.get("genNumber")) {
-            logger.debug("Skipping record {}", record.getMetadata().getKey());
+            logger.debug("Skipping record {}",
+                    formatterInput.getRecord().getMetadata().getKey());
             return new SkipOutboundRecord<>(MediaType.OCTET_STREAM,
-                    formattedRecord.getMetadata());
+                    formatterInput.getFormattedRecord().getMetadata());
         }
 
         // Return built-in JSON formatted record.
-        return formattedRecord;
+        return formatterInput.getFormattedRecord();
     }
 }

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/esp/EspSkipTransformer.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/esp/EspSkipTransformer.java
@@ -58,7 +58,7 @@ public class EspSkipTransformer implements Transformer {
 
     @Override
     public ChangeNotificationRecord transform(
-            @NonNull ChangeNotificationRecord record) throws Exception {
+            @NonNull ChangeNotificationRecord record) {
         // Record generation is not shipped by Aerospike XDR versions before
         // v5.0.0.
         Optional<Integer> generation = record.getMetadata().getGeneration();

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/esp/EspWrapBuiltinJsonFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/esp/EspWrapBuiltinJsonFormatter.java
@@ -18,11 +18,11 @@
 
 package com.aerospike.connect.outbound.transformer.examples.esp;
 
-import com.aerospike.connect.outbound.ChangeNotificationRecord;
 import com.aerospike.connect.outbound.esp.EspOutboundMetadata;
 import com.aerospike.connect.outbound.format.BytesOutboundRecord;
 import com.aerospike.connect.outbound.format.DefaultBytesOutboundRecord;
 import com.aerospike.connect.outbound.format.Formatter;
+import com.aerospike.connect.outbound.format.FormatterInput;
 import com.aerospike.connect.outbound.format.MediaType;
 import com.aerospike.connect.outbound.format.OutboundRecord;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -61,13 +61,14 @@ public class EspWrapBuiltinJsonFormatter
 
     @Override
     public OutboundRecord<EspOutboundMetadata> format(
-            @NonNull ChangeNotificationRecord record,
-            @NonNull OutboundRecord<EspOutboundMetadata> formattedRecord)
+            @NonNull FormatterInput<EspOutboundMetadata> formatterInput)
             throws JsonProcessingException {
-        logger.debug("Formatting record {}", record.getMetadata().getKey());
+        logger.debug("Formatting record {}",
+                formatterInput.getRecord().getMetadata().getKey());
 
         byte[] payload =
-                ((BytesOutboundRecord<EspOutboundMetadata>) formattedRecord)
+                ((BytesOutboundRecord<EspOutboundMetadata>)
+                        formatterInput.getFormattedRecord())
                         .getPayload()
                         .orElseThrow(() -> new IllegalArgumentException(
                                 "payload missing, expected json payload"));
@@ -79,7 +80,8 @@ public class EspWrapBuiltinJsonFormatter
         byte[] jsonRecordPayload = objectMapper.writeValueAsBytes(jsonRecord);
 
         return new DefaultBytesOutboundRecord<>(jsonRecordPayload,
-                MediaType.JSON, formattedRecord.getMetadata(),
+                MediaType.JSON,
+                formatterInput.getFormattedRecord().getMetadata(),
                 Collections.emptySet());
     }
 }

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/jms/JmsKeyValueFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/jms/JmsKeyValueFormatter.java
@@ -18,10 +18,10 @@
 
 package com.aerospike.connect.outbound.transformer.examples.jms;
 
-import com.aerospike.connect.outbound.ChangeNotificationRecord;
 import com.aerospike.connect.outbound.format.DefaultTextOutboundRecord;
 import com.aerospike.connect.outbound.format.Formatter;
 import com.aerospike.connect.outbound.format.FormatterConfig;
+import com.aerospike.connect.outbound.format.FormatterInput;
 import com.aerospike.connect.outbound.format.MediaType;
 import com.aerospike.connect.outbound.format.OutboundRecord;
 import com.aerospike.connect.outbound.jms.JmsOutboundMetadata;
@@ -65,15 +65,18 @@ public class JmsKeyValueFormatter implements Formatter<JmsOutboundMetadata> {
 
     @Override
     public OutboundRecord<JmsOutboundMetadata> format(
-            @NonNull ChangeNotificationRecord record,
-            @NonNull OutboundRecord<JmsOutboundMetadata> formattedRecord) {
-        logger.debug("Formatting record {}", record.getMetadata().getKey());
+            @NonNull FormatterInput<JmsOutboundMetadata> formatterInput)
+            throws Exception {
+
+        logger.debug("Formatting record {}",
+                formatterInput.getRecord().getMetadata().getKey());
 
         // Only write string bins.
         StringBuilder payloadBuilder = new StringBuilder();
         String separator =
                 (String) configParams.getOrDefault("separator", ":");
-        for (Map.Entry<String, Object> bin : record.getBins().entrySet()) {
+        for (Map.Entry<String, Object> bin : formatterInput.getRecord()
+                .getBins().entrySet()) {
             if (bin.getValue() instanceof String) {
                 payloadBuilder.append(bin.getKey());
                 payloadBuilder.append(separator);
@@ -84,6 +87,7 @@ public class JmsKeyValueFormatter implements Formatter<JmsOutboundMetadata> {
 
         return new DefaultTextOutboundRecord<>(
                 payloadBuilder.toString().getBytes(), MediaType.OCTET_STREAM,
-                formattedRecord.getMetadata(), Collections.emptySet());
+                formatterInput.getFormattedRecord().getMetadata(),
+                Collections.emptySet());
     }
 }

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/jms/JmsKeyValueFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/jms/JmsKeyValueFormatter.java
@@ -65,8 +65,7 @@ public class JmsKeyValueFormatter implements Formatter<JmsOutboundMetadata> {
 
     @Override
     public OutboundRecord<JmsOutboundMetadata> format(
-            @NonNull FormatterInput<JmsOutboundMetadata> formatterInput)
-            throws Exception {
+            @NonNull FormatterInput<JmsOutboundMetadata> formatterInput) {
 
         logger.debug("Formatting record {}",
                 formatterInput.getRecord().getMetadata().getKey());

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/jms/JmsMessageTypeFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/jms/JmsMessageTypeFormatter.java
@@ -68,8 +68,7 @@ public class JmsMessageTypeFormatter implements Formatter<JmsOutboundMetadata> {
 
     @Override
     public OutboundRecord<JmsOutboundMetadata> format(
-            @NonNull FormatterInput<JmsOutboundMetadata> formatterInput)
-            throws Exception {
+            @NonNull FormatterInput<JmsOutboundMetadata> formatterInput) {
         logger.debug("Formatting record {}",
                 formatterInput.getRecord().getMetadata().getKey());
 

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/jms/JmsMessageTypeFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/jms/JmsMessageTypeFormatter.java
@@ -18,12 +18,12 @@
 
 package com.aerospike.connect.outbound.transformer.examples.jms;
 
-import com.aerospike.connect.outbound.ChangeNotificationRecord;
 import com.aerospike.connect.outbound.format.BytesOutboundRecord;
 import com.aerospike.connect.outbound.format.DefaultBytesOutboundRecord;
 import com.aerospike.connect.outbound.format.DefaultTextOutboundRecord;
 import com.aerospike.connect.outbound.format.Formatter;
 import com.aerospike.connect.outbound.format.FormatterConfig;
+import com.aerospike.connect.outbound.format.FormatterInput;
 import com.aerospike.connect.outbound.format.OutboundRecord;
 import com.aerospike.connect.outbound.jms.JmsOutboundMetadata;
 import lombok.NonNull;
@@ -68,10 +68,13 @@ public class JmsMessageTypeFormatter implements Formatter<JmsOutboundMetadata> {
 
     @Override
     public OutboundRecord<JmsOutboundMetadata> format(
-            @NonNull ChangeNotificationRecord record,
-            @NonNull OutboundRecord<JmsOutboundMetadata> formattedRecord) {
-        logger.debug("Formatting record {}", record.getMetadata().getKey());
+            @NonNull FormatterInput<JmsOutboundMetadata> formatterInput)
+            throws Exception {
+        logger.debug("Formatting record {}",
+                formatterInput.getRecord().getMetadata().getKey());
 
+        OutboundRecord<JmsOutboundMetadata> formattedRecord =
+                formatterInput.getFormattedRecord();
         byte[] payload =
                 ((BytesOutboundRecord<JmsOutboundMetadata>) formattedRecord)
                         .getPayload()
@@ -84,12 +87,14 @@ public class JmsMessageTypeFormatter implements Formatter<JmsOutboundMetadata> {
             // Will be dispatched as JMS TextMessage.
             return new DefaultTextOutboundRecord<>(payload,
                     formattedRecord.getMediaType(),
-                    formattedRecord.getMetadata(), Collections.emptySet());
+                    formattedRecord.getMetadata(),
+                    Collections.emptySet());
         } else {
             // Will be dispatched as JMS BytesMessage.
             return new DefaultBytesOutboundRecord<>(payload,
                     formattedRecord.getMediaType(),
-                    formattedRecord.getMetadata(), Collections.emptySet());
+                    formattedRecord.getMetadata(),
+                    Collections.emptySet());
         }
     }
 }

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/jms/JmsSkipFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/jms/JmsSkipFormatter.java
@@ -66,8 +66,7 @@ public class JmsSkipFormatter implements Formatter<JmsOutboundMetadata> {
 
     @Override
     public OutboundRecord<JmsOutboundMetadata> format(
-            @NonNull FormatterInput<JmsOutboundMetadata> formatterInput)
-            throws Exception {
+            @NonNull FormatterInput<JmsOutboundMetadata> formatterInput) {
         logger.debug("Formatting record {}",
                 formatterInput.getRecord().getMetadata().getKey());
 

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/jms/JmsSkipFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/jms/JmsSkipFormatter.java
@@ -18,9 +18,9 @@
 
 package com.aerospike.connect.outbound.transformer.examples.jms;
 
-import com.aerospike.connect.outbound.ChangeNotificationRecord;
 import com.aerospike.connect.outbound.format.Formatter;
 import com.aerospike.connect.outbound.format.FormatterConfig;
+import com.aerospike.connect.outbound.format.FormatterInput;
 import com.aerospike.connect.outbound.format.MediaType;
 import com.aerospike.connect.outbound.format.OutboundRecord;
 import com.aerospike.connect.outbound.format.SkipOutboundRecord;
@@ -66,24 +66,27 @@ public class JmsSkipFormatter implements Formatter<JmsOutboundMetadata> {
 
     @Override
     public OutboundRecord<JmsOutboundMetadata> format(
-            @NonNull ChangeNotificationRecord record,
-            @NonNull OutboundRecord<JmsOutboundMetadata> formattedRecord) {
-        logger.debug("Formatting record {}", record.getMetadata().getKey());
+            @NonNull FormatterInput<JmsOutboundMetadata> formatterInput)
+            throws Exception {
+        logger.debug("Formatting record {}",
+                formatterInput.getRecord().getMetadata().getKey());
 
         // Record generation is not shipped by Aerospike XDR versions before
         // v5.0.0.
-        Optional<Integer> generation = record.getMetadata().getGeneration();
+        Optional<Integer> generation =
+                formatterInput.getRecord().getMetadata().getGeneration();
 
         // "genNumber" is to be set in params option of the JMS formatter
         // config.
         if (generation.isPresent() &&
                 generation.get() > (int) configParams.get("genNumber")) {
-            logger.debug("Skipping record {}", record.getMetadata().getKey());
+            logger.debug("Skipping record {}",
+                    formatterInput.getRecord().getMetadata().getKey());
             return new SkipOutboundRecord<>(MediaType.OCTET_STREAM,
-                    formattedRecord.getMetadata());
+                    formatterInput.getFormattedRecord().getMetadata());
         }
 
         // Return built-in JSON formatted record.
-        return formattedRecord;
+        return formatterInput.getFormattedRecord();
     }
 }

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/jms/JmsSkipTransformer.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/jms/JmsSkipTransformer.java
@@ -58,7 +58,7 @@ public class JmsSkipTransformer implements Transformer {
 
     @Override
     public ChangeNotificationRecord transform(
-            @NonNull ChangeNotificationRecord record) throws Exception {
+            @NonNull ChangeNotificationRecord record) {
         // Record generation is not shipped by Aerospike XDR versions before
         // v5.0.0.
         Optional<Integer> generation = record.getMetadata().getGeneration();

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/kafka/KafkaKeyValueFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/kafka/KafkaKeyValueFormatter.java
@@ -66,8 +66,7 @@ public class KafkaKeyValueFormatter
 
     @Override
     public OutboundRecord<KafkaOutboundMetadata> format(
-            @NonNull FormatterInput<KafkaOutboundMetadata> formatterInput)
-            throws Exception {
+            @NonNull FormatterInput<KafkaOutboundMetadata> formatterInput) {
         logger.debug("Formatting record {}",
                 formatterInput.getRecord().getMetadata().getKey());
 

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/kafka/KafkaKeyValueFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/kafka/KafkaKeyValueFormatter.java
@@ -18,10 +18,10 @@
 
 package com.aerospike.connect.outbound.transformer.examples.kafka;
 
-import com.aerospike.connect.outbound.ChangeNotificationRecord;
 import com.aerospike.connect.outbound.format.DefaultTextOutboundRecord;
 import com.aerospike.connect.outbound.format.Formatter;
 import com.aerospike.connect.outbound.format.FormatterConfig;
+import com.aerospike.connect.outbound.format.FormatterInput;
 import com.aerospike.connect.outbound.format.MediaType;
 import com.aerospike.connect.outbound.format.OutboundRecord;
 import com.aerospike.connect.outbound.kafka.KafkaOutboundMetadata;
@@ -66,15 +66,17 @@ public class KafkaKeyValueFormatter
 
     @Override
     public OutboundRecord<KafkaOutboundMetadata> format(
-            @NonNull ChangeNotificationRecord record,
-            @NonNull OutboundRecord<KafkaOutboundMetadata> formattedRecord) {
-        logger.debug("Formatting record {}", record.getMetadata().getKey());
+            @NonNull FormatterInput<KafkaOutboundMetadata> formatterInput)
+            throws Exception {
+        logger.debug("Formatting record {}",
+                formatterInput.getRecord().getMetadata().getKey());
 
         // Only write string bins.
         StringBuilder payloadBuilder = new StringBuilder();
         String separator =
                 (String) configParams.getOrDefault("separator", ":");
-        for (Map.Entry<String, Object> bin : record.getBins().entrySet()) {
+        for (Map.Entry<String, Object> bin : formatterInput.getRecord()
+                .getBins().entrySet()) {
             if (bin.getValue() instanceof String) {
                 payloadBuilder.append(bin.getKey());
                 payloadBuilder.append(separator);
@@ -85,6 +87,7 @@ public class KafkaKeyValueFormatter
 
         return new DefaultTextOutboundRecord<>(
                 payloadBuilder.toString().getBytes(), MediaType.OCTET_STREAM,
-                formattedRecord.getMetadata(), Collections.emptySet());
+                formatterInput.getFormattedRecord().getMetadata(),
+                Collections.emptySet());
     }
 }

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/kafka/KafkaSkipFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/kafka/KafkaSkipFormatter.java
@@ -18,9 +18,9 @@
 
 package com.aerospike.connect.outbound.transformer.examples.kafka;
 
-import com.aerospike.connect.outbound.ChangeNotificationRecord;
 import com.aerospike.connect.outbound.format.Formatter;
 import com.aerospike.connect.outbound.format.FormatterConfig;
+import com.aerospike.connect.outbound.format.FormatterInput;
 import com.aerospike.connect.outbound.format.MediaType;
 import com.aerospike.connect.outbound.format.OutboundRecord;
 import com.aerospike.connect.outbound.format.SkipOutboundRecord;
@@ -66,24 +66,27 @@ public class KafkaSkipFormatter implements Formatter<KafkaOutboundMetadata> {
 
     @Override
     public OutboundRecord<KafkaOutboundMetadata> format(
-            @NonNull ChangeNotificationRecord record,
-            @NonNull OutboundRecord<KafkaOutboundMetadata> formattedRecord) {
-        logger.debug("Formatting record {}", record.getMetadata().getKey());
+            @NonNull FormatterInput<KafkaOutboundMetadata> formatterInput)
+            throws Exception {
+        logger.debug("Formatting record {}",
+                formatterInput.getRecord().getMetadata().getKey());
 
         // Record generation is not shipped by Aerospike XDR versions before
         // v5.0.0.
-        Optional<Integer> generation = record.getMetadata().getGeneration();
+        Optional<Integer> generation =
+                formatterInput.getRecord().getMetadata().getGeneration();
 
         // "genNumber" is to be set in params option of the Kafka formatter
         // config.
         if (generation.isPresent() &&
                 generation.get() > (int) configParams.get("genNumber")) {
-            logger.debug("Skipping record {}", record.getMetadata().getKey());
+            logger.debug("Skipping record {}",
+                    formatterInput.getRecord().getMetadata().getKey());
             return new SkipOutboundRecord<>(MediaType.OCTET_STREAM,
-                    formattedRecord.getMetadata());
+                    formatterInput.getFormattedRecord().getMetadata());
         }
 
         // Return built-in JSON formatted record.
-        return formattedRecord;
+        return formatterInput.getFormattedRecord();
     }
 }

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/kafka/KafkaSkipFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/kafka/KafkaSkipFormatter.java
@@ -66,8 +66,7 @@ public class KafkaSkipFormatter implements Formatter<KafkaOutboundMetadata> {
 
     @Override
     public OutboundRecord<KafkaOutboundMetadata> format(
-            @NonNull FormatterInput<KafkaOutboundMetadata> formatterInput)
-            throws Exception {
+            @NonNull FormatterInput<KafkaOutboundMetadata> formatterInput) {
         logger.debug("Formatting record {}",
                 formatterInput.getRecord().getMetadata().getKey());
 

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/kafka/KafkaSkipTransformer.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/kafka/KafkaSkipTransformer.java
@@ -58,7 +58,7 @@ public class KafkaSkipTransformer implements Transformer {
 
     @Override
     public ChangeNotificationRecord transform(
-            @NonNull ChangeNotificationRecord record) throws Exception {
+            @NonNull ChangeNotificationRecord record) {
         // Record generation is not shipped by Aerospike XDR versions before
         // v5.0.0.
         Optional<Integer> generation = record.getMetadata().getGeneration();

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/kafka/KafkaWrapBuiltinJsonFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/kafka/KafkaWrapBuiltinJsonFormatter.java
@@ -18,10 +18,10 @@
 
 package com.aerospike.connect.outbound.transformer.examples.kafka;
 
-import com.aerospike.connect.outbound.ChangeNotificationRecord;
 import com.aerospike.connect.outbound.format.BytesOutboundRecord;
 import com.aerospike.connect.outbound.format.DefaultBytesOutboundRecord;
 import com.aerospike.connect.outbound.format.Formatter;
+import com.aerospike.connect.outbound.format.FormatterInput;
 import com.aerospike.connect.outbound.format.MediaType;
 import com.aerospike.connect.outbound.format.OutboundRecord;
 import com.aerospike.connect.outbound.kafka.KafkaOutboundMetadata;
@@ -61,13 +61,13 @@ public class KafkaWrapBuiltinJsonFormatter
 
     @Override
     public OutboundRecord<KafkaOutboundMetadata> format(
-            @NonNull ChangeNotificationRecord record,
-            @NonNull OutboundRecord<KafkaOutboundMetadata> formattedRecord)
+            @NonNull FormatterInput<KafkaOutboundMetadata> formatterInput)
             throws JsonProcessingException {
-        logger.debug("Formatting record {}", record.getMetadata().getKey());
+        logger.debug("Formatting record {}",
+                formatterInput.getRecord().getMetadata().getKey());
 
         byte[] payload =
-                ((BytesOutboundRecord<KafkaOutboundMetadata>) formattedRecord)
+                ((BytesOutboundRecord<KafkaOutboundMetadata>) formatterInput.getFormattedRecord())
                         .getPayload()
                         .orElseThrow(() -> new IllegalArgumentException(
                                 "payload missing, expected json payload"));
@@ -79,7 +79,8 @@ public class KafkaWrapBuiltinJsonFormatter
         byte[] jsonRecordPayload = objectMapper.writeValueAsBytes(jsonRecord);
 
         return new DefaultBytesOutboundRecord<>(jsonRecordPayload,
-                MediaType.JSON, formattedRecord.getMetadata(),
+                MediaType.JSON,
+                formatterInput.getFormattedRecord().getMetadata(),
                 Collections.emptySet());
     }
 }

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pubsub/PubSubKeyValueFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pubsub/PubSubKeyValueFormatter.java
@@ -18,10 +18,10 @@
 
 package com.aerospike.connect.outbound.transformer.examples.pubsub;
 
-import com.aerospike.connect.outbound.ChangeNotificationRecord;
 import com.aerospike.connect.outbound.format.DefaultTextOutboundRecord;
 import com.aerospike.connect.outbound.format.Formatter;
 import com.aerospike.connect.outbound.format.FormatterConfig;
+import com.aerospike.connect.outbound.format.FormatterInput;
 import com.aerospike.connect.outbound.format.MediaType;
 import com.aerospike.connect.outbound.format.OutboundRecord;
 import com.aerospike.connect.outbound.pubsub.PubSubOutboundMetadata;
@@ -70,18 +70,19 @@ public class PubSubKeyValueFormatter
         configParams = formatterConfig.getParams();
     }
 
-
     @Override
     public OutboundRecord<PubSubOutboundMetadata> format(
-            @NonNull ChangeNotificationRecord record,
-            @NonNull OutboundRecord<PubSubOutboundMetadata> formattedRecord) {
-        logger.debug("Formatting record {}", record.getMetadata().getKey());
+            @NonNull FormatterInput<PubSubOutboundMetadata> formatterInput)
+            throws Exception {
+        logger.debug("Formatting record {}",
+                formatterInput.getRecord().getMetadata().getKey());
 
         // Only write string bins.
         StringBuilder payloadBuilder = new StringBuilder();
         String separator =
                 (String) configParams.getOrDefault("separator", ":");
-        for (Map.Entry<String, Object> bin : record.getBins().entrySet()) {
+        for (Map.Entry<String, Object> bin : formatterInput.getRecord()
+                .getBins().entrySet()) {
             if (bin.getValue() instanceof String) {
                 payloadBuilder.append(bin.getKey());
                 payloadBuilder.append(separator);
@@ -91,20 +92,23 @@ public class PubSubKeyValueFormatter
         }
 
         // If attribute colour is present add it to the payload as well.
-        formattedRecord.getMetadata().getAttributes().ifPresent(attributes -> {
-            if (attributes.containsKey("colour")) {
-                payloadBuilder.append("colour");
-                payloadBuilder.append(separator);
-                payloadBuilder.append(attributes.get("colour"));
-                payloadBuilder.append(System.lineSeparator());
-            }
-        });
+        formatterInput.getFormattedRecord().getMetadata().getAttributes()
+                .ifPresent(attributes -> {
+                    if (attributes.containsKey("colour")) {
+                        payloadBuilder.append("colour");
+                        payloadBuilder.append(separator);
+                        payloadBuilder.append(attributes.get("colour"));
+                        payloadBuilder.append(System.lineSeparator());
+                    }
+                });
 
         // Add ordering key. "regional-endpoint" should be configured for this
         // record in the config.
         String orderingKey = "CustomFormatter";
         PubSubOutboundMetadata metadata = new PubSubOutboundMetadata(
-                formattedRecord.getMetadata().getAttributes().orElse(null),
+                formatterInput.getFormattedRecord().getMetadata()
+                        .getAttributes()
+                        .orElse(null),
                 orderingKey);
 
         return new DefaultTextOutboundRecord<>(

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pubsub/PubSubKeyValueFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pubsub/PubSubKeyValueFormatter.java
@@ -72,8 +72,7 @@ public class PubSubKeyValueFormatter
 
     @Override
     public OutboundRecord<PubSubOutboundMetadata> format(
-            @NonNull FormatterInput<PubSubOutboundMetadata> formatterInput)
-            throws Exception {
+            @NonNull FormatterInput<PubSubOutboundMetadata> formatterInput) {
         logger.debug("Formatting record {}",
                 formatterInput.getRecord().getMetadata().getKey());
 

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pubsub/PubSubSkipFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pubsub/PubSubSkipFormatter.java
@@ -18,9 +18,9 @@
 
 package com.aerospike.connect.outbound.transformer.examples.pubsub;
 
-import com.aerospike.connect.outbound.ChangeNotificationRecord;
 import com.aerospike.connect.outbound.format.Formatter;
 import com.aerospike.connect.outbound.format.FormatterConfig;
+import com.aerospike.connect.outbound.format.FormatterInput;
 import com.aerospike.connect.outbound.format.MediaType;
 import com.aerospike.connect.outbound.format.OutboundRecord;
 import com.aerospike.connect.outbound.format.SkipOutboundRecord;
@@ -66,24 +66,27 @@ public class PubSubSkipFormatter implements Formatter<PubSubOutboundMetadata> {
 
     @Override
     public OutboundRecord<PubSubOutboundMetadata> format(
-            @NonNull ChangeNotificationRecord record,
-            @NonNull OutboundRecord<PubSubOutboundMetadata> formattedRecord) {
-        logger.debug("Formatting record {}", record.getMetadata().getKey());
+            @NonNull FormatterInput<PubSubOutboundMetadata> formatterInput)
+            throws Exception {
+        logger.debug("Formatting record {}",
+                formatterInput.getRecord().getMetadata().getKey());
 
         // Record generation is not shipped by Aerospike XDR versions before
         // v5.0.0.
-        Optional<Integer> generation = record.getMetadata().getGeneration();
+        Optional<Integer> generation =
+                formatterInput.getRecord().getMetadata().getGeneration();
 
         // "genNumber" is to be set in params option of the PubSub formatter
         // config.
         if (generation.isPresent() &&
                 generation.get() > (int) configParams.get("genNumber")) {
-            logger.debug("Skipping record {}", record.getMetadata().getKey());
+            logger.debug("Skipping record {}",
+                    formatterInput.getRecord().getMetadata().getKey());
             return new SkipOutboundRecord<>(MediaType.OCTET_STREAM,
-                    formattedRecord.getMetadata());
+                    formatterInput.getFormattedRecord().getMetadata());
         }
 
         // Return built-in JSON formatted record.
-        return formattedRecord;
+        return formatterInput.getFormattedRecord();
     }
 }

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pubsub/PubSubSkipFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pubsub/PubSubSkipFormatter.java
@@ -66,8 +66,7 @@ public class PubSubSkipFormatter implements Formatter<PubSubOutboundMetadata> {
 
     @Override
     public OutboundRecord<PubSubOutboundMetadata> format(
-            @NonNull FormatterInput<PubSubOutboundMetadata> formatterInput)
-            throws Exception {
+            @NonNull FormatterInput<PubSubOutboundMetadata> formatterInput) {
         logger.debug("Formatting record {}",
                 formatterInput.getRecord().getMetadata().getKey());
 

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pubsub/PubSubSkipTransformer.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pubsub/PubSubSkipTransformer.java
@@ -59,7 +59,7 @@ public class PubSubSkipTransformer implements Transformer {
 
     @Override
     public ChangeNotificationRecord transform(
-            @NonNull ChangeNotificationRecord record) throws Exception {
+            @NonNull ChangeNotificationRecord record) {
         // Record generation is not shipped by Aerospike XDR versions before
         // v5.0.0.
         Optional<Integer> generation = record.getMetadata().getGeneration();

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pubsub/PubSubWrapBuiltinJsonFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pubsub/PubSubWrapBuiltinJsonFormatter.java
@@ -18,10 +18,10 @@
 
 package com.aerospike.connect.outbound.transformer.examples.pubsub;
 
-import com.aerospike.connect.outbound.ChangeNotificationRecord;
 import com.aerospike.connect.outbound.format.BytesOutboundRecord;
 import com.aerospike.connect.outbound.format.DefaultBytesOutboundRecord;
 import com.aerospike.connect.outbound.format.Formatter;
+import com.aerospike.connect.outbound.format.FormatterInput;
 import com.aerospike.connect.outbound.format.MediaType;
 import com.aerospike.connect.outbound.format.OutboundRecord;
 import com.aerospike.connect.outbound.pubsub.PubSubOutboundMetadata;
@@ -61,13 +61,13 @@ public class PubSubWrapBuiltinJsonFormatter
 
     @Override
     public OutboundRecord<PubSubOutboundMetadata> format(
-            @NonNull ChangeNotificationRecord record,
-            @NonNull OutboundRecord<PubSubOutboundMetadata> formattedRecord)
+            @NonNull FormatterInput<PubSubOutboundMetadata> formatterInput)
             throws JsonProcessingException {
-        logger.debug("Formatting record {}", record.getMetadata().getKey());
+        logger.debug("Formatting record {}",
+                formatterInput.getRecord().getMetadata().getKey());
 
         byte[] payload =
-                ((BytesOutboundRecord<PubSubOutboundMetadata>) formattedRecord)
+                ((BytesOutboundRecord<PubSubOutboundMetadata>) formatterInput.getFormattedRecord())
                         .getPayload()
                         .orElseThrow(() -> new IllegalArgumentException(
                                 "payload missing, expected json payload"));
@@ -79,7 +79,8 @@ public class PubSubWrapBuiltinJsonFormatter
         byte[] jsonRecordPayload = objectMapper.writeValueAsBytes(jsonRecord);
 
         return new DefaultBytesOutboundRecord<>(jsonRecordPayload,
-                MediaType.JSON, formattedRecord.getMetadata(),
+                MediaType.JSON,
+                formatterInput.getFormattedRecord().getMetadata(),
                 Collections.emptySet());
     }
 }

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pulsar/PulsarKeyValueFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pulsar/PulsarKeyValueFormatter.java
@@ -66,8 +66,7 @@ public class PulsarKeyValueFormatter
 
     @Override
     public OutboundRecord<PulsarOutboundMetadata> format(
-            @NonNull FormatterInput<PulsarOutboundMetadata> formatterInput)
-            throws Exception {
+            @NonNull FormatterInput<PulsarOutboundMetadata> formatterInput) {
         logger.debug("Formatting record {}",
                 formatterInput.getRecord().getMetadata().getKey());
 

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pulsar/PulsarKeyValueFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pulsar/PulsarKeyValueFormatter.java
@@ -18,10 +18,10 @@
 
 package com.aerospike.connect.outbound.transformer.examples.pulsar;
 
-import com.aerospike.connect.outbound.ChangeNotificationRecord;
 import com.aerospike.connect.outbound.format.DefaultTextOutboundRecord;
 import com.aerospike.connect.outbound.format.Formatter;
 import com.aerospike.connect.outbound.format.FormatterConfig;
+import com.aerospike.connect.outbound.format.FormatterInput;
 import com.aerospike.connect.outbound.format.MediaType;
 import com.aerospike.connect.outbound.format.OutboundRecord;
 import com.aerospike.connect.outbound.pulsar.PulsarOutboundMetadata;
@@ -66,15 +66,17 @@ public class PulsarKeyValueFormatter
 
     @Override
     public OutboundRecord<PulsarOutboundMetadata> format(
-            @NonNull ChangeNotificationRecord record,
-            @NonNull OutboundRecord<PulsarOutboundMetadata> formattedRecord) {
-        logger.debug("Formatting record {}", record.getMetadata().getKey());
+            @NonNull FormatterInput<PulsarOutboundMetadata> formatterInput)
+            throws Exception {
+        logger.debug("Formatting record {}",
+                formatterInput.getRecord().getMetadata().getKey());
 
         // Only write string bins.
         StringBuilder payloadBuilder = new StringBuilder();
         String separator =
                 (String) configParams.getOrDefault("separator", ":");
-        for (Map.Entry<String, Object> bin : record.getBins().entrySet()) {
+        for (Map.Entry<String, Object> bin : formatterInput.getRecord()
+                .getBins().entrySet()) {
             if (bin.getValue() instanceof String) {
                 payloadBuilder.append(bin.getKey());
                 payloadBuilder.append(separator);
@@ -85,6 +87,7 @@ public class PulsarKeyValueFormatter
 
         return new DefaultTextOutboundRecord<>(
                 payloadBuilder.toString().getBytes(), MediaType.OCTET_STREAM,
-                formattedRecord.getMetadata(), Collections.emptySet());
+                formatterInput.getFormattedRecord().getMetadata(),
+                Collections.emptySet());
     }
 }

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pulsar/PulsarSkipFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pulsar/PulsarSkipFormatter.java
@@ -18,9 +18,9 @@
 
 package com.aerospike.connect.outbound.transformer.examples.pulsar;
 
-import com.aerospike.connect.outbound.ChangeNotificationRecord;
 import com.aerospike.connect.outbound.format.Formatter;
 import com.aerospike.connect.outbound.format.FormatterConfig;
+import com.aerospike.connect.outbound.format.FormatterInput;
 import com.aerospike.connect.outbound.format.MediaType;
 import com.aerospike.connect.outbound.format.OutboundRecord;
 import com.aerospike.connect.outbound.format.SkipOutboundRecord;
@@ -66,24 +66,27 @@ public class PulsarSkipFormatter implements Formatter<PulsarOutboundMetadata> {
 
     @Override
     public OutboundRecord<PulsarOutboundMetadata> format(
-            @NonNull ChangeNotificationRecord record,
-            @NonNull OutboundRecord<PulsarOutboundMetadata> formattedRecord) {
-        logger.debug("Formatting record {}", record.getMetadata().getKey());
+            @NonNull FormatterInput<PulsarOutboundMetadata> formatterInput)
+            throws Exception {
+        logger.debug("Formatting record {}",
+                formatterInput.getRecord().getMetadata().getKey());
 
         // Record generation is not shipped by Aerospike XDR versions before
         // v5.0.0.
-        Optional<Integer> generation = record.getMetadata().getGeneration();
+        Optional<Integer> generation =
+                formatterInput.getRecord().getMetadata().getGeneration();
 
         // "genNumber" is to be set in params option of the Pulsar formatter
         // config.
         if (generation.isPresent() &&
                 generation.get() > (int) configParams.get("genNumber")) {
-            logger.debug("Skipping record {}", record.getMetadata().getKey());
+            logger.debug("Skipping record {}",
+                    formatterInput.getRecord().getMetadata().getKey());
             return new SkipOutboundRecord<>(MediaType.OCTET_STREAM,
-                    formattedRecord.getMetadata());
+                    formatterInput.getFormattedRecord().getMetadata());
         }
 
         // Return built-in JSON formatted record.
-        return formattedRecord;
+        return formatterInput.getFormattedRecord();
     }
 }

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pulsar/PulsarSkipFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pulsar/PulsarSkipFormatter.java
@@ -66,8 +66,7 @@ public class PulsarSkipFormatter implements Formatter<PulsarOutboundMetadata> {
 
     @Override
     public OutboundRecord<PulsarOutboundMetadata> format(
-            @NonNull FormatterInput<PulsarOutboundMetadata> formatterInput)
-            throws Exception {
+            @NonNull FormatterInput<PulsarOutboundMetadata> formatterInput) {
         logger.debug("Formatting record {}",
                 formatterInput.getRecord().getMetadata().getKey());
 

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pulsar/PulsarSkipTransformer.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pulsar/PulsarSkipTransformer.java
@@ -59,7 +59,7 @@ public class PulsarSkipTransformer implements Transformer {
 
     @Override
     public ChangeNotificationRecord transform(
-            @NonNull ChangeNotificationRecord record) throws Exception {
+            @NonNull ChangeNotificationRecord record) {
         // Record generation is not shipped by Aerospike XDR versions before
         // v5.0.0.
         Optional<Integer> generation = record.getMetadata().getGeneration();

--- a/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pulsar/PulsarWrapBuiltinJsonFormatter.java
+++ b/examples/gradle/src/main/java/com/aerospike/connect/outbound/transformer/examples/pulsar/PulsarWrapBuiltinJsonFormatter.java
@@ -18,10 +18,10 @@
 
 package com.aerospike.connect.outbound.transformer.examples.pulsar;
 
-import com.aerospike.connect.outbound.ChangeNotificationRecord;
 import com.aerospike.connect.outbound.format.BytesOutboundRecord;
 import com.aerospike.connect.outbound.format.DefaultBytesOutboundRecord;
 import com.aerospike.connect.outbound.format.Formatter;
+import com.aerospike.connect.outbound.format.FormatterInput;
 import com.aerospike.connect.outbound.format.MediaType;
 import com.aerospike.connect.outbound.format.OutboundRecord;
 import com.aerospike.connect.outbound.pulsar.PulsarOutboundMetadata;
@@ -61,13 +61,13 @@ public class PulsarWrapBuiltinJsonFormatter
 
     @Override
     public OutboundRecord<PulsarOutboundMetadata> format(
-            @NonNull ChangeNotificationRecord record,
-            @NonNull OutboundRecord<PulsarOutboundMetadata> formattedRecord)
+            @NonNull FormatterInput<PulsarOutboundMetadata> formatterInput)
             throws JsonProcessingException {
-        logger.debug("Formatting record {}", record.getMetadata().getKey());
+        logger.debug("Formatting record {}",
+                formatterInput.getRecord().getMetadata().getKey());
 
         byte[] payload =
-                ((BytesOutboundRecord<PulsarOutboundMetadata>) formattedRecord)
+                ((BytesOutboundRecord<PulsarOutboundMetadata>) formatterInput.getFormattedRecord())
                         .getPayload()
                         .orElseThrow(() -> new IllegalArgumentException(
                                 "payload missing, expected json payload"));
@@ -79,7 +79,8 @@ public class PulsarWrapBuiltinJsonFormatter
         byte[] jsonRecordPayload = objectMapper.writeValueAsBytes(jsonRecord);
 
         return new DefaultBytesOutboundRecord<>(jsonRecordPayload,
-                MediaType.JSON, formattedRecord.getMetadata(),
+                MediaType.JSON,
+                formatterInput.getFormattedRecord().getMetadata(),
                 Collections.emptySet());
     }
 }

--- a/examples/maven/pom.xml
+++ b/examples/maven/pom.xml
@@ -31,8 +31,8 @@
          running the outbound connector -->
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <repositories>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.aerospike</groupId>
             <artifactId>aerospike-connect-outbound-sdk</artifactId>
-            <version>1.2.0</version>
+            <version>2.0.0-SNAPSHOT</version>
             <scope>provided</scope> <!-- Do not include in JAR -->
         </dependency>
         <dependency>
@@ -113,16 +113,16 @@
 
     <build>
         <plugins>
-            <!-- Compile to Java 1.8 -->
+            <!-- Compile to Java 11 -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <testSource>1.8</testSource>
-                    <testTarget>1.8</testTarget>
+                    <source>11</source>
+                    <target>11</target>
+                    <testSource>11</testSource>
+                    <testTarget>11</testTarget>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
                         <arg>-Werror</arg>

--- a/examples/maven/pom.xml
+++ b/examples/maven/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.0</version>
+            <version>2.15.1</version>
         </dependency>
 
         <!-- 2. COMPILE ONLY DEPENDENCIES, INCLUDED AT RUNTIME BY
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.aerospike</groupId>
             <artifactId>aerospike-client</artifactId>
-            <version>6.1.9</version>
+            <version>6.1.10</version>
             <scope>provided</scope> <!-- Do not include in JAR -->
         </dependency>
 
@@ -74,7 +74,7 @@
             <groupId>com.aerospike</groupId>
             <artifactId>aerospike-connect-elasticsearch-outbound-sdk
             </artifactId>
-            <version>1.0.0</version>
+            <version>2.0.0-SNAPSHOT</version>
             <scope>provided</scope> <!-- Do not include in JAR -->
         </dependency>
 

--- a/examples/maven/pom.xml
+++ b/examples/maven/pom.xml
@@ -31,8 +31,8 @@
          running the outbound connector -->
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <repositories>
@@ -113,16 +113,16 @@
 
     <build>
         <plugins>
-            <!-- Compile to Java 11 -->
+            <!-- Compile to Java 1.8 -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                    <testSource>11</testSource>
-                    <testTarget>11</testTarget>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <testSource>1.8</testSource>
+                    <testTarget>1.8</testTarget>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
                         <arg>-Werror</arg>

--- a/outbound-sdk/gradle.properties
+++ b/outbound-sdk/gradle.properties
@@ -15,5 +15,4 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 #
-version=1.2.1-SNAPSHOT
-
+version=2.0.0-SNAPSHOT

--- a/outbound-sdk/src/main/java/com/aerospike/connect/outbound/format/Formatter.java
+++ b/outbound-sdk/src/main/java/com/aerospike/connect/outbound/format/Formatter.java
@@ -77,7 +77,7 @@ public interface Formatter<T extends OutboundMetadata> {
      * @deprecated use {@link #format(FormatterInput)}
      */
     @SuppressWarnings("unused")
-    @Deprecated(since = "2.0.0", forRemoval = true)
+    @Deprecated
     default OutboundRecord<T> format(@NonNull ChangeNotificationRecord record,
                                      @NonNull OutboundRecord<T> formattedRecord)
             throws Exception {

--- a/outbound-sdk/src/main/java/com/aerospike/connect/outbound/format/Formatter.java
+++ b/outbound-sdk/src/main/java/com/aerospike/connect/outbound/format/Formatter.java
@@ -40,14 +40,14 @@ public interface Formatter<T extends OutboundMetadata> {
      * Format a record into a custom format.
      *
      * <p>
-     * The {@code formattedRecord} is an instance of either {@link
-     * BytesOutboundRecord} or {@link TextOutboundRecord}. The {@code payload}
-     * in the {@code formattedRecord} is {@code null} unless the {@code
-     * `payload-format`} config in the custom formatter is set to one of the
-     * built-in outbound formats - AVRO, FlatJSON, etc. The {@code
-     * formattedRecord} is an instance of {@link TextOutboundRecord} only when
-     * the custom formatter is configured with the FlatJSON or JSON built-in
-     * outbound formats.
+     * The {@code formattedRecord} is an instance of either
+     * {@link BytesOutboundRecord} or {@link TextOutboundRecord}. The
+     * {@code payload} in the {@code formattedRecord} is {@code null} unless the
+     * {@code `payload-format`} config in the custom formatter is set to one of
+     * the built-in outbound formats - AVRO, FlatJSON, etc. The
+     * {@code formattedRecord} is an instance of {@link TextOutboundRecord} only
+     * when the custom formatter is configured with the FlatJSON or JSON
+     * built-in outbound formats.
      *
      * <p>
      * The return types should be instances of
@@ -74,8 +74,20 @@ public interface Formatter<T extends OutboundMetadata> {
      * @throws Exception if failed to format the record. The record is
      *                   acknowledged with temporary error to Aerospike XDR
      *                   change notification.
+     * @deprecated use {@link #format(FormatterInput)}
      */
-    OutboundRecord<T> format(@NonNull ChangeNotificationRecord record,
-                             @NonNull OutboundRecord<T> formattedRecord)
-            throws Exception;
+    @SuppressWarnings("unused")
+    @Deprecated(since = "2.0.0", forRemoval = true)
+    default OutboundRecord<T> format(@NonNull ChangeNotificationRecord record,
+                                     @NonNull OutboundRecord<T> formattedRecord)
+            throws Exception {
+        throw new Exception(
+                "implement Formatter.format(FormatterInput<T>)");
+    }
+
+    default OutboundRecord<T> format(@NonNull FormatterInput<T> formatterInput)
+            throws Exception {
+        return format(formatterInput.getRecord(),
+                formatterInput.getFormattedRecord());
+    }
 }

--- a/outbound-sdk/src/main/java/com/aerospike/connect/outbound/format/FormatterInput.java
+++ b/outbound-sdk/src/main/java/com/aerospike/connect/outbound/format/FormatterInput.java
@@ -20,38 +20,36 @@ package com.aerospike.connect.outbound.format;
 
 import com.aerospike.connect.outbound.ChangeNotificationRecord;
 import com.aerospike.connect.outbound.routing.OutboundRoute;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NonNull;
-import lombok.ToString;
 
 /**
- * A batch item passed to the {@link BatchFormatter}.
+ * Input to {@link Formatter}.
  *
  * @param <T> the metadata associated with the outbound records.
  */
-@AllArgsConstructor
-@EqualsAndHashCode
-@Getter
-@ToString
-public class BatchItem<T extends OutboundMetadata>
-        implements FormatterInput<T> {
+public interface FormatterInput<T extends OutboundMetadata> {
     /**
-     * @see FormatterInput#getRecord()
+     * @return the change notification record shipped by Aerospike XDR
      */
     @NonNull
-    private ChangeNotificationRecord record;
+    ChangeNotificationRecord getRecord();
 
     /**
-     * @see FormatterInput#getFormattedRecord()
+     * @return a {@code formattedRecord} which is an instance of either
+     * {@link BytesOutboundRecord} or {@link TextOutboundRecord}. The
+     * {@code payload} in the {@code formattedRecord} is {@code null} unless the
+     * {@code `payload-format`} config in the custom formatter is set to one of
+     * the built-in outbound formats - AVRO, FlatJSON, etc. The
+     * {@code formattedRecord} is an instance of {@link TextOutboundRecord} only
+     * when the custom formatter is configured with the FlatJSON or JSON
+     * built-in outbound formats.
      */
     @NonNull
-    private OutboundRecord<T> formattedRecord;
+    OutboundRecord<T> getFormattedRecord();
 
     /**
-     * @see FormatterInput#getOutboundRoute()
+     * @return the route this item will be dispatched
      */
     @NonNull
-    private OutboundRoute<?> outboundRoute;
+    OutboundRoute<?> getOutboundRoute();
 }

--- a/outbound-sdk/src/main/java/com/aerospike/connect/outbound/routing/OutboundRoute.java
+++ b/outbound-sdk/src/main/java/com/aerospike/connect/outbound/routing/OutboundRoute.java
@@ -18,21 +18,16 @@
 
 package com.aerospike.connect.outbound.routing;
 
-import com.aerospike.connect.outbound.esp.EspOutboundRoute;
-import com.aerospike.connect.outbound.jms.JmsOutboundRoute;
-import com.aerospike.connect.outbound.kafka.KafkaOutboundRoute;
 import com.aerospike.connect.outbound.pubsub.PubSubOutboundRoute;
-import com.aerospike.connect.outbound.pulsar.PulsarOutboundRoute;
 import lombok.NonNull;
-
-import javax.annotation.Nullable;
 
 /**
  * The route to the outbound destination.
  *
  * @param <T> the type of the outbound route. Should be a String type for ESP
- *            (Event Stream Processing), JMS, Kafka, Pulsar routes; and a {@link
- *            PubSubOutboundRoute PubSubOutboundRoute} type for Google Pub/Sub.
+ *            (Event Stream Processing), JMS, Kafka, Pulsar routes; and a
+ *            {@link PubSubOutboundRoute PubSubOutboundRoute} type for Google
+ *            Pub/Sub.
  */
 public interface OutboundRoute<T> {
     /**
@@ -50,70 +45,4 @@ public interface OutboundRoute<T> {
      */
     @NonNull
     T getRoute();
-
-    /**
-     * Create an outbound route to an ESP (Event Stream Processing)
-     * destination.
-     *
-     * @param destination the destination name configured in ESP config.
-     * @return the outbound route for an ESP destination.
-     * @deprecated replaced by {@link EspOutboundRoute}.
-     */
-    @Deprecated
-    static DefaultOutboundRoute<String> newEspRoute(String destination) {
-        return new EspOutboundRoute(destination);
-    }
-
-    /**
-     * Create an outbound route to a JMS destination.
-     *
-     * @param type        type of the JMS destination.
-     * @param destination the JMS destination name.
-     * @return the outbound route for a JMS destination.
-     * @deprecated replaced by {@link JmsOutboundRoute}.
-     */
-    @Deprecated
-    static DefaultOutboundRoute<String> newJmsRoute(OutboundRouteType type,
-                                                    String destination) {
-        return new JmsOutboundRoute(type, destination);
-    }
-
-    /**
-     * Create an outbound route to a Kafka topic.
-     *
-     * @param topic the Kafka topic name.
-     * @return the outbound route for a Kafka topic.
-     * @deprecated replaced by {@link KafkaOutboundRoute}.
-     */
-    @Deprecated
-    static DefaultOutboundRoute<String> newKafkaRoute(String topic) {
-        return new KafkaOutboundRoute(topic);
-    }
-
-    /**
-     * Create an outbound route to a Pulsar topic.
-     *
-     * @param topic the Pulsar topic name.
-     * @return the outbound route for a Pulsar topic.
-     * @deprecated replaced by {@link PulsarOutboundRoute}.
-     */
-    @Deprecated
-    static DefaultOutboundRoute<String> newPulsarRoute(String topic) {
-        return new PulsarOutboundRoute(topic);
-    }
-
-    /**
-     * Create an outbound route to a Google Pub/Sub destination.
-     *
-     * @param topic            the Google Pub/Sub topic name.
-     * @param regionalEndpoint the regional endpoint to publish the message to.
-     * @return the outbound route for a Google Pub/Sub topic.
-     * @deprecated replaced by {@link PubSubOutboundRoute}.
-     */
-    @Deprecated
-    static DefaultOutboundRoute<PubSubOutboundRoute> newPubSubRoute(
-            String topic, @Nullable String regionalEndpoint) {
-        return new DefaultOutboundRoute<>(OutboundRouteType.TOPIC,
-                new PubSubOutboundRoute(topic, regionalEndpoint));
-    }
 }


### PR DESCRIPTION
* `OutboundRoute` is sent as an input to `Formatter` and `BatchFormatter`
  * Deprecated older `format` method
* Removed previously deprecated method from `OutboundRoute`
* Breaking changes into `BulkRequestConfig`
  * Removed the `index` parameter which is now part of the connector's config
  * Changed the type of `timeout` field
* Upgraded dependencies
* Updated examples