### PR TITLE
Dependency upgrades

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath("io.freefair.gradle:lombok-plugin:8.1.0")
+        classpath("io.freefair.gradle:lombok-plugin:8.4")
     }
 }
 
@@ -69,9 +69,14 @@ subprojects {
         mavenCentral()
     }
 
+    dependencies {
+        // TODO: Investigate. Snyk fails on older version of this dependency.
+        "dataFiles"("org.json:json:20231013")
+    }
+
     group = "com.aerospike"
 
-    project.extra["jacksonVersion"] = "2.15.2"
+    project.extra["jacksonVersion"] = "2.15.3"
 
     setupJavaBuild()
     setupReleaseTasks()

--- a/elasticsearch-outbound-sdk/build.gradle.kts
+++ b/elasticsearch-outbound-sdk/build.gradle.kts
@@ -18,16 +18,20 @@
 
 dependencies {
     // Aerospike connect outbound sdk
-    api("com.aerospike:aerospike-connect-outbound-sdk:2.2.0")
+    compileOnly("com.aerospike:aerospike-connect-outbound-sdk:2.2.0")
 
     // Elasticsearch client
-    api("co.elastic.clients:elasticsearch-java:8.9.0")
+    compileOnly("co.elastic.clients:elasticsearch-java:8.10.4")
 
-    // Jackson annotations
+    // Jackson dependencies
     compileOnly(
-        "com.fasterxml.jackson.core:jackson-annotations:${project.extra["jacksonVersion"]}"
+        "com.fasterxml.jackson.core:jackson-annotations:${
+            project.extra["jacksonVersion"]
+        }",
     )
     compileOnly(
-        "com.fasterxml.jackson.core:jackson-databind:${project.extra["jacksonVersion"]}"
+        "com.fasterxml.jackson.core:jackson-databind:${
+            project.extra["jacksonVersion"]
+        }",
     )
 }

--- a/outbound-sdk/build.gradle.kts
+++ b/outbound-sdk/build.gradle.kts
@@ -25,9 +25,13 @@ dependencies {
 
     // Jackson annotations
     compileOnly(
-        "com.fasterxml.jackson.core:jackson-annotations:${project.extra["jacksonVersion"]}"
+        "com.fasterxml.jackson.core:jackson-annotations:${
+            project.extra["jacksonVersion"]
+        }",
     )
     compileOnly(
-        "com.fasterxml.jackson.core:jackson-databind:${project.extra["jacksonVersion"]}"
+        "com.fasterxml.jackson.core:jackson-databind:${
+            project.extra["jacksonVersion"]
+        }",
     )
 }


### PR DESCRIPTION
* Upgraded a few dependencies
* Added extra `org.json` as a separate dependency until the fix from the Snyk plugin is released
* Made Elasticsearch SDK dependencies `compileOnly`
* Fixed formatting