### PR TITLE
[CONNECTOR-1431] Aerospike Streaming Connectors - Security vulnerabilities - Jackson-core

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -3,9 +3,5 @@ ignore:
     - '*':
         reason: Library Exception allows non-free use of gnu-crypto
         expires: 2026-12-31T11:38:28.614Z
-  'SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551':
-    - '*':
-        reason: Jackson 2.18.7 is under development and can't upgrade to 2.21.2 due to conflicts in inbound connectors
-        expires: 2026-04-30T11:38:28.614Z
 exclude:
   - ./examples

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,8 @@ subprojects {
 
     group = "com.aerospike"
 
-    project.extra["jacksonVersion"] = "2.18.6"
+    project.extra["jacksonVersion"] = "2.21.2"
+    project.extra["jacksonAnnotationVersion"] = "2.21"
 
     setupJavaBuild()
     setupReleaseTasks()

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     api("com.github.breadmoirai:github-release:2.5.2")
     api("com.github.ben-manes:gradle-versions-plugin:+")
 
-    val jacksonVersion = "2.18.6"
+    val jacksonVersion = "2.21.2"
     api("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     api("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
 }

--- a/elasticsearch-outbound-sdk/build.gradle.kts
+++ b/elasticsearch-outbound-sdk/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     api(project(":aerospike-connect-outbound-sdk"))
 
     // Elasticsearch client
-    api("co.elastic.clients:elasticsearch-java:8.19.14") {
+    api("co.elastic.clients:elasticsearch-java:8.19.11") {
         // Exclude the Jackson 3 packages which require Java 17
         exclude("tools.jackson.core")
         exclude("tools.jackson")

--- a/elasticsearch-outbound-sdk/build.gradle.kts
+++ b/elasticsearch-outbound-sdk/build.gradle.kts
@@ -18,7 +18,7 @@
 
 dependencies {
     // Aerospike connect outbound sdk
-    api("com.aerospike:aerospike-connect-outbound-sdk:2.3.2")
+    api(project(":aerospike-connect-outbound-sdk"))
 
     // Elasticsearch client
     api("co.elastic.clients:elasticsearch-java:8.19.14") {

--- a/outbound-sdk/build.gradle.kts
+++ b/outbound-sdk/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     // Jackson annotations
     api(
         "com.fasterxml.jackson.core:jackson-annotations:${
-            project.extra["jacksonVersion"]
+            project.extra["jacksonAnnotationVersion"]
         }"
     )
     api(

--- a/outbound-sdk/build.gradle.kts
+++ b/outbound-sdk/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     api("jakarta.annotation:jakarta.annotation-api:3.0.0")
 
     // Aerospike Java Client
-    api("com.aerospike:aerospike-client-jdk8:10.0.0")
+    api("com.aerospike:aerospike-client-jdk8:9.3.0")
 
     // Jackson annotations
     api(


### PR DESCRIPTION
* Removed the ignore Jackson vulnerability entry
* Upgraded jackson library to 2.21.2 to fix vulnerability
* Aligned dependency versions used by the connectors