### PR TITLE
[CONNECTOR-1558] Upgrade Jackson and Elasticsearch client dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,7 +78,7 @@ subprojects {
 
     group = "com.aerospike"
 
-    project.extra["jacksonVersion"] = "2.21.4"
+    project.extra["jacksonVersion"] = "2.22.1"
     project.extra["jacksonAnnotationVersion"] = "2.21"
 
     configureProperties()

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     api("com.github.breadmoirai:github-release:2.5.2")
     api("com.github.ben-manes:gradle-versions-plugin:+")
 
-    val jacksonVersion = "2.21.4"
+    val jacksonVersion = "2.22.1"
     api("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     api("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
 }

--- a/elasticsearch-outbound-sdk/build.gradle.kts
+++ b/elasticsearch-outbound-sdk/build.gradle.kts
@@ -18,10 +18,10 @@
 
 dependencies {
     // Aerospike connect outbound sdk
-    api("com.aerospike:aerospike-connect-outbound-sdk:3.0.0")
+    api(project(":aerospike-connect-outbound-sdk"))
 
     // Elasticsearch client
-    api("co.elastic.clients:elasticsearch-java:8.19.11") {
+    api("co.elastic.clients:elasticsearch-java:9.4.3") {
         // Exclude the Jackson 3 packages which require Java 17
         exclude("tools.jackson.core")
         exclude("tools.jackson")

--- a/elasticsearch-outbound-sdk/build.gradle.kts
+++ b/elasticsearch-outbound-sdk/build.gradle.kts
@@ -22,7 +22,10 @@ dependencies {
 
     // Elasticsearch client
     api("co.elastic.clients:elasticsearch-java:9.4.3") {
-        // Exclude the Jackson 3 packages which require Java 17
+        // Exclude unused vulnerable/incpmatible transitive dependencies
+        exclude("io.opentelemetry", "opentelemetry-api")
+        exclude("org.apache.httpcomponents.core5", "httpcore5-h2")
+        exclude("org.eclipse.parsson", "parsson")
         exclude("tools.jackson.core")
         exclude("tools.jackson")
     }


### PR DESCRIPTION
## Summary
- Bump Jackson from 2.21.4 to 2.22.1 across root and buildSrc configurations
- Upgrade Elasticsearch Java client from 8.19.11 to 9.4.3 in elasticsearch-outbound-sdk
- Switch elasticsearch-outbound-sdk to use the local `:aerospike-connect-outbound-sdk` project dependency instead of the published 3.0.0 artifact

## Test plan
- [x] Run `./gradlew build` and verify all modules compile successfully
- [x] Run elasticsearch-outbound-sdk tests to confirm compatibility with Elasticsearch client 9.4.3
- [x] Verify Jackson 2.22.1 resolves correctly and no dependency conflicts remain


Made with [Cursor](https://cursor.com)